### PR TITLE
Update mathjax.html

### DIFF
--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,17 +1,12 @@
-<!--
-Author: Ray-Eldath
-refer to:
- - http://docs.mathjax.org/en/latest/options/index.html
--->
 {% if site.mathjax %}
 	<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script id="MathJax-script" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
 		jax: ["input/TeX", "output/HTML-CSS"],
 		tex2jax: {
-			inlineMath: [ ["$", "$"] ],
-			displayMath: [ ["$$", "$$"] ],
+			inlineMath: [['$', '$'], ["\\(", "\\)"]],
+			processEscapes: true,
 			skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
 		},
 		"HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"] }


### PR DESCRIPTION
All problems mentioned in #14 have been solved。
Here is the new post [https://tanglongbin.github.io/ME4300-Modern-Control-System.html](url), the latex of which works well!

If you don't mind it, please accept the PR to make sure mathjax goes well in the future.